### PR TITLE
Develop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ RUN apk add --no-cache tzdata curl postgresql-client busybox-suid
 # Configurar zona horaria para Colombia (America/Bogota)
 ENV TZ=America/Bogota
 
+# Crear directorio de logs
+RUN mkdir -p /app/logs && chmod 777 /app/logs
+
 # Copiar archivos de dependencias
 COPY package.json bun.lock ./
 
@@ -21,7 +24,7 @@ COPY . .
 RUN npx prisma generate
 
 # Agregar el script de sincronización al crontab
-RUN echo "0 6 * * * cd /app && npm run sync >> /var/log/cron.log 2>&1" > /etc/crontabs/root
+RUN echo "0 6 * * * cd /app && npm run sync >> /app/logs/cron.log 2>&1" > /etc/crontabs/root
 
 # Exponer puerto
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM node:20-alpine
 
 WORKDIR /app
 
-# Instalar herramientas necesarias
-RUN apk add --no-cache tzdata curl postgresql-client cron
+# Instalar herramientas necesarias (busybox-suid en lugar de cron)
+RUN apk add --no-cache tzdata curl postgresql-client busybox-suid
 
 # Configurar zona horaria para Colombia (America/Bogota)
 ENV TZ=America/Bogota

--- a/README.md
+++ b/README.md
@@ -53,8 +53,23 @@ docker-compose exec app npm run sync
 Los logs de sincronización se almacenan en la carpeta `logs/`:
 
 ```bash
-# Ver los logs más recientes
+# Ver los logs de sincronización del día
 docker-compose exec app cat /app/logs/sync-$(date +%Y-%m-%d).log
+
+# Ver los logs del cron
+docker-compose exec app cat /app/logs/cron.log
+```
+
+### Solución de problemas
+
+Si necesitas verificar que el cron está configurado correctamente:
+
+```bash
+# Ver tareas de cron configuradas
+docker-compose exec app cat /etc/crontabs/root
+
+# Verificar procesos en ejecución (incluido crond)
+docker-compose exec app ps -ef
 ```
 
 ## Estructura del Proyecto
@@ -75,7 +90,6 @@ La aplicación utiliza:
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
 ## Getting Started
-components.json, eslint.config.mjs, next.config.ts, postcss.config.mjs, tsconfig.json, prisma/migrations/, src/components/ui/
 First, run the development server:
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+version: '3.8'
 
 services:
   # Aplicación Next.js

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,9 +1,29 @@
 #!/bin/sh
 set -e
 
+# Crear directorio de logs si no existe
+mkdir -p /app/logs
+touch /var/log/cron.log
+
 # Iniciar el servicio de cron en segundo plano
 echo "Iniciando servicio de cron..."
-crond -b -l 8
+/usr/sbin/crond -b -l 8
+
+# Verificar que cron esté funcionando
+echo "Verificando servicio de cron:"
+ps | grep crond
+
+# Esperar a que la base de datos esté disponible
+echo "Esperando a que la base de datos esté disponible..."
+while ! pg_isready -h db -U postgres; do
+  echo "PostgreSQL no está disponible aún - esperando..."
+  sleep 1
+done
+echo "Base de datos lista"
+
+# Ejecutar migraciones de Prisma
+echo "Ejecutando migraciones de Prisma..."
+npx prisma migrate deploy
 
 # Iniciar la aplicación Next.js
 echo "Iniciando la aplicación..."


### PR DESCRIPTION
This pull request introduces updates to the Docker setup, logging configuration, and documentation for the project. Key changes include replacing the `cron` package with `busybox-suid`, improving log management, and enhancing the `docker-entrypoint.sh` script to handle database readiness and Prisma migrations. Additionally, the `README.md` has been updated with troubleshooting steps and log access instructions.

### Docker Setup and Logging Improvements:
* Replaced the `cron` package with `busybox-suid` in the `Dockerfile` and updated the cron job to write logs to `/app/logs/cron.log` instead of `/var/log/cron.log`. A new `/app/logs` directory is created with appropriate permissions. (`Dockerfile`: [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L5-R13) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L24-R27)
* Added a new `docker-entrypoint.sh` script to initialize the logs directory, verify `cron` is running, wait for the database to be ready, and execute Prisma migrations before starting the application. (`docker-entrypoint.sh`: [docker-entrypoint.shR4-R26](diffhunk://#diff-79738685a656fe6b25061bb14181442210b599f746faeaba408a2401de45038aR4-R26))

### Documentation Updates:
* Updated the `README.md` to include instructions for viewing synchronization logs (`sync-$(date +%Y-%m-%d).log`) and cron logs (`cron.log`). Added troubleshooting steps to verify cron configuration and running processes. (`README.md`: [README.mdL56-R72](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L56-R72))
* Minor cleanup in the `README.md` to remove unnecessary placeholders. (`README.md`: [README.mdL78](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L78))

### Other Changes:
* Added a `version: '3.8'` declaration to the `docker-compose.yml` file for compatibility. (`docker-compose.yml`: [docker-compose.ymlR1](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R1))